### PR TITLE
Create Fat library for macOS

### DIFF
--- a/.github/workflows/ledger_ffi_builder.yml
+++ b/.github/workflows/ledger_ffi_builder.yml
@@ -60,7 +60,7 @@ jobs:
           cargo lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --release
           install_name_tool -id @rpath/../Frameworks/libledger_ffi_x86_64.dylib target/x86_64-apple-darwin/release/libledger_ffi.dylib
           install_name_tool -id @rpath/../Frameworks/libledger_ffi_arch64.dylib target/aarch64-apple-darwin/release/libledger_ffi.dylib
-          lipo target/x86_64-apple-darwin/release/libledger_ffi.dylib target/aarch64-apple-darwin/release/libledger_ffi.dylib -output darwin-universal/libledger_ffi.dylib
+          lipo target/x86_64-apple-darwin/release/libledger_ffi.dylib target/aarch64-apple-darwin/release/libledger_ffi.dylib -output darwin-universal/libledger_ffi.dylib -create
       - name: Archive files
         run: |
           zip -jr libledger_ffi-darwin-universal.zip darwin-universal/*

--- a/.github/workflows/ledger_ffi_builder.yml
+++ b/.github/workflows/ledger_ffi_builder.yml
@@ -52,8 +52,7 @@ jobs:
           cargo install cargo-lipo
       - name: Create output directories
         run: |
-          mkdir darwin-amd64
-          mkdir darwin-arch64
+          mkdir darwin-universal
           mkdir releases
       - name: Build
         run: | 

--- a/.github/workflows/ledger_ffi_builder.yml
+++ b/.github/workflows/ledger_ffi_builder.yml
@@ -60,16 +60,13 @@ jobs:
           cargo lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --release
           install_name_tool -id @rpath/../Frameworks/libledger_ffi_x86_64.dylib target/x86_64-apple-darwin/release/libledger_ffi.dylib
           install_name_tool -id @rpath/../Frameworks/libledger_ffi_arch64.dylib target/aarch64-apple-darwin/release/libledger_ffi.dylib
-          cp target/x86_64-apple-darwin/release/libledger_ffi.dylib darwin-amd64/
-          cp target/aarch64-apple-darwin/release/libledger_ffi.dylib darwin-arch64/
+          lipo target/x86_64-apple-darwin/release/libledger_ffi.dylib target/aarch64-apple-darwin/release/libledger_ffi.dylib -output darwin-universal/libledger_ffi.dylib
       - name: Archive files
         run: |
-          zip -jr libledger_ffi-darwin-amd64.zip darwin-amd64/*
-          zip -jr libledger_ffi-darwin-arch64.zip darwin-arch64/*
+          zip -jr libledger_ffi-darwin-universal.zip darwin-universal/*
       - name: Copy archived files to releases
         run: |
-          cp libledger_ffi-darwin-amd64.zip releases/
-          cp libledger_ffi-darwin-arch64.zip releases/
+          cp libledger_ffi-darwin-universal.zip releases/
       - uses: actions/upload-artifact@v3
         with:
           name: macos-artifacts
@@ -140,7 +137,7 @@ jobs:
           - name: Prepare releases directory
             run: |
               mkdir releases
-              cp libledger_ffi-darwin-amd64.zip libledger_ffi-darwin-arch64.zip libledger_ffi-linux-amd64.zip libledger_ffi-windows-amd64.zip releases/
+              cp libledger_ffi-darwin-universal.zip libledger_ffi-linux-amd64.zip libledger_ffi-windows-amd64.zip releases/
           - name: Generate checksums
             run: | 
               cd releases/


### PR DESCRIPTION
This PR changes the build workflow for macOS to create a Fat library containing both the amd64 and arch64 libraries.